### PR TITLE
Fix npm install ffi-napi error

### DIFF
--- a/src/ffi.cc
+++ b/src/ffi.cc
@@ -2,6 +2,8 @@
 #include "fficonfig.h"
 #include <get-uv-event-loop-napi.h>
 
+uv_loop_t* loop = get_uv_event_loop(env);
+
 namespace FFI {
 
 static int __ffi_errno() { return errno; }


### PR DESCRIPTION
Try to fix this error when install ffi-napi:
c:\users\practicas02\documents\proyectos\navegador electron adif\aplicacion electron\electron_adif\app\node_modules\ffi-napi\src\ffi.cc(3): fatal error C1083: No se puede abrir el archivo incluir: 'get-uv-event-loop-n
api.h': No such file or directory [C:\Users\Practicas02\Documents\Proyectos\Navegador Electron ADIF\Aplicacion Electron\electron_adif\app\node_modules\ffi-napi\build\ffi_bindings.vcxproj]

Check "Usage" in: https://github.com/node-ffi-napi/get-uv-event-loop-napi-h