### PR TITLE
chore: pin node-addon-api to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bindings": "^1.3.0",
     "debug": "^3.1.0",
     "get-uv-event-loop-napi-h": "^1.0.5",
-    "node-addon-api": "^1.1.0",
+    "node-addon-api": "1.5.0",
     "ref-napi": "^1.4.0",
     "ref-struct-di": "^1.1.0"
   },


### PR DESCRIPTION
unable to build due to the recent breaking changes in node-addon-api(1.6.0). This PR will pin the version to 1.5.0 until node-addon-api fix the compatibility issue. 

https://github.com/nodejs/node-addon-api/issues/387