### PR TITLE
Added arm64 job in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ node_js:
   - "14"
 
 jobs:
+  include:
+      - os: linux
+        arch: arm64
+        node_js: 12
+        env: CXX=g++-4.9
   exclude:
       - os: osx
         env: CXX=g++-4.9

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "install": "node-gyp-build",
-    "prebuild": "prebuildify --napi",
+    "prebuild": "prebuildify --napi --tag-armv",
     "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '4' ] || (echo 'Some prebuilds are missing'; exit 1))",
     "test": "node-gyp rebuild --directory test && nyc mocha --expose-gc --reporter spec"
   },


### PR DESCRIPTION
As per the discussion https://github.com/node-ffi-napi/node-ffi-napi/issues/77, added support for arm64 in Travis-ci for prebuild binary release.