### PR TITLE
Target Node.js v14 in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     # node.js
     - nodejs_version: "10"
     - nodejs_version: "12"
+    - nodejs_version: "14"
 
 platform:
   - x86


### PR DESCRIPTION
- Tests in `.travis.yml` target Node.js v14.
- Tests in `appveyor.yml` should also target Node.js v14.