### PR TITLE
Make ffi-napi work on Android under Termux

### DIFF
--- a/deps/libffi/libffi.gyp
+++ b/deps/libffi/libffi.gyp
@@ -149,7 +149,7 @@
         },'target_arch=="arm64"', {
           'sources': [ 'src/aarch64/ffi.c' ],
           'conditions': [
-            ['OS=="linux" or OS=="mac"', {
+            ['OS=="linux" or OS=="mac" or OS=="android"', {
               'sources': [ 'src/aarch64/sysv.S' ]
             }],
             ['OS=="win"', {

--- a/lib/library.js
+++ b/lib/library.js
@@ -17,6 +17,7 @@ const RTLD_NOW = DynamicLibrary.FLAGS.RTLD_NOW;
 const EXT = Library.EXT = {
   'linux':  '.so',
   'linux2': '.so',
+  'android':'.so',
   'sunos':  '.so',
   'solaris':'.so',
   'freebsd':'.so',


### PR DESCRIPTION
These small changes make ffi-napi compile and work in Termux under Android.