### PR TITLE
Add arm64 prebuild for Apple Silicon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,11 @@ jobs:
         arch: arm64
         node_js: 12
         env: CXX=g++-4.9
+      - os: osx
+        arch: arm64
+        osx_image: xcode12.5
+        node_js: 16
+        env: CXX=clang++
   exclude:
       - os: osx
         env: CXX=g++-4.9

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "install": "node-gyp-build",
     "prebuild": "prebuildify --napi --tag-armv --tag-uv",
-    "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '5' ] || (echo 'Some prebuilds are missing'; exit 1))",
+    "prepack": "prebuildify-ci download && ([ $(ls prebuilds | wc -l) = '6' ] || (echo 'Some prebuilds are missing'; exit 1))",
     "test": "node-gyp rebuild --directory test && nyc mocha --expose-gc --reporter spec"
   },
   "repository": {


### PR DESCRIPTION
macOS developers on Apple Silicon need to recompile ffi-napi right now:

>Error: No native build was found for platform=darwin arch=arm64 runtime=node abi=93 uv=1 armv=8 libc=glibc node=16.7.0
>    loaded from: node_modules/ref-napi
>
>    at Function.load.path (node_modules/node-gyp-build/index.js:59:9)

This follows the example in #78 to add an arm64 target for macOS. I'm not
able to test Travis CI so hopefully this actually does the right thing!