### PR TITLE
Workaround assertion failed of uv_close (#197)

### DIFF
--- a/src/ffi.cc
+++ b/src/ffi.cc
@@ -14,6 +14,7 @@ InstanceData* InstanceData::Get(Env env) {
 }
 
 void InstanceData::Dispose() {
+  if (async.type != UV_ASYNC) return;
   uv_close(reinterpret_cast<uv_handle_t*>(&async), [](uv_handle_t* handle) {
     InstanceData* self = static_cast<InstanceData*>(handle->data);
     uv_mutex_destroy(&self->mutex);


### PR DESCRIPTION
This pull request will try to workaround #197.

`CallbackInfo::Initialize` was probably not being called before `InstanceData::Dispose`, causing the call on `uv_close` with uninitialized `async` member.

I don't know why this racing condition was happened. But checking the type of `async` before calling `uv_close` can workaround the failure.