### PR TITLE
fix: node_api.gyp not found in windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,7 @@
       "<!@(node -p \"require('ref-napi/lib/get-paths').include\")",
     ],
     'dependencies': [
-      "<!(node -p \"require('node-addon-api').gyp\")",
+      "<!@(node -p \"require('node-addon-api').gyp\")",
       "deps/libffi/libffi.gyp:ffi"
     ],
     'cflags!': [ '-fno-exceptions' ],


### PR DESCRIPTION
fixes #227