### PR TITLE
Fix build failure with node-gyp@^10.0.0

### DIFF
--- a/deps/libffi/libffi.gyp
+++ b/deps/libffi/libffi.gyp
@@ -74,8 +74,7 @@
               '<(INTERMEDIATE_DIR)/<(RULE_INPUT_ROOT).asm',
             ],
             'action': [
-              'call',
-              'preprocess_asm.cmd',
+              '../../../deps/libffi/preprocess_asm.cmd',
                 'include',
                 'config/<(OS)/<(target_arch)',
                 '<(RULE_INPUT_PATH)',


### PR DESCRIPTION
This fixes build failures relating to `'"call"' is not recognized as an internal or external command` on Windows.